### PR TITLE
xvba-video: apply patches to fix build errors

### DIFF
--- a/xvba-video/xvba-video.SlackBuild
+++ b/xvba-video/xvba-video.SlackBuild
@@ -68,6 +68,11 @@ tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
 cd $PRGNAM-$VERSION
 tar xvf $CWD/xvba-sdk-$SDKVERSION.tar.gz
 
+cat $CWD/xvba-video_glext.patch \
+  | patch -p1 --verbose 2>&1 | tee $OUTPUT/patch-${PRGNAM}.log
+cat $CWD/xvba-video_VAEncH264SEIBufferType.patch \
+  | patch -p1 --verbose 2>&1 | tee -a $OUTPUT/patch-${PRGNAM}.log
+
 chown -R root:root .
 find . \
  \( -perm 777 -o -perm 775 -o -perm 711 -o -perm 555 -o -perm 511 \) \

--- a/xvba-video/xvba-video_VAEncH264SEIBufferType.patch
+++ b/xvba-video/xvba-video_VAEncH264SEIBufferType.patch
@@ -1,0 +1,13 @@
+--- xvba-video-0.8.0/src/xvba_dump.c~	2011-06-14 13:07:13.000000000 +0200
++++ xvba-video-0.8.0/src/xvba_dump.c	2015-06-04 15:46:58.385987460 +0200
+@@ -150,8 +150,8 @@
+         _(VAEncSequenceParameterBufferType);
+         _(VAEncPictureParameterBufferType);
+         _(VAEncSliceParameterBufferType);
+-        _(VAEncH264VUIBufferType);
+-        _(VAEncH264SEIBufferType);
++//        _(VAEncH264VUIBufferType);
++//        _(VAEncH264SEIBufferType);
+ #endif
+ #undef _
+     }

--- a/xvba-video/xvba-video_glext.patch
+++ b/xvba-video/xvba-video_glext.patch
@@ -1,0 +1,16 @@
+--- xvba-video-0.8.0/src/utils_glx.h~	2011-06-14 13:07:13.000000000 +0200
++++ xvba-video-0.8.0/src/utils_glx.h	2015-06-04 15:48:26.651987155 +0200
+@@ -25,6 +25,13 @@
+ #include <GL/glext.h>
+ #include <GL/glx.h>
+ 
++#if GL_GLEXT_VERSION >= 85
++/* XXX: PFNGLMULTITEXCOORD2FPROC got out of the GL_VERSION_1_3_DEPRECATED
++   block and is not defined if GL_VERSION_1_3 is defined in <GL/gl.h>
++   Redefine the type here as an interim solution */
++typedef void (*PFNGLMULTITEXCOORD2FPROC) (GLenum target, GLfloat s, GLfloat t);
++#endif
++
+ #ifndef GL_FRAMEBUFFER_BINDING
+ #define GL_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING_EXT
+ #endif


### PR DESCRIPTION
The patches are taken from http://www.slackware.com/~alien/slackbuilds/libva-vdpau-driver/build/
